### PR TITLE
fix: use --global git config in sync workflow to fix empty ident error

### DIFF
--- a/.github/workflows/sync-to-liberwerkio.yml
+++ b/.github/workflows/sync-to-liberwerkio.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Push to LiberWerk.github.io
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
           # Clone the target repo
           git clone git@github.com:LiberWerk/LiberWerk.github.io.git /tmp/target


### PR DESCRIPTION
## Context

Issue #33 — \`sync-to-liberwerkio.yml\` 워크플로우가 2026-06-07부터 계속 실패하여 tangoenskai.github.io의 변경사항이 liberwerk.github.io에 전혀 반영되지 않고 있었다.

## What

\`.github/workflows/sync-to-liberwerkio.yml\`의 \`git config\` 명령에 \`--global\` 플래그 추가.

```diff
- git config user.name "github-actions[bot]"
- git config user.email "github-actions[bot]@users.noreply.github.com"
+ git config --global user.name "github-actions[bot]"
+ git config --global user.email "github-actions[bot]@users.noreply.github.com"
```

## Why

\`git config\` (로컬)는 현재 디렉토리의 레포에만 적용된다. 워크플로우에서 \`git clone\`으로 생성한 \`/tmp/target\`으로 이동 후 commit할 때 committer identity가 없어 아래 에러 발생:

```
fatal: empty ident name (for <runner@...>) not allowed
```

\`--global\`로 변경하면 runner 전체에 적용되어 \`/tmp/target\`에서도 identity가 유효하다.

## Completion Criteria

- [x] \`sync-to-liberwerkio.yml\` 워크플로우 성공
- [x] tangoenskai.github.io → liberwerk.github.io 자동 동기화 정상 작동

close #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)