### PR TITLE
fix(seo): add hreflang, OG, and Twitter Card meta to contact.html

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,29 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Get in Touch — LiberWerk</title>
   <meta name="description" content="Enquire about advisory services — CTO-as-a-Service, VP of Engineering consulting, and technical advisory by Mark Hahn." />
+
+  <!-- hreflang -->
+  <link rel="alternate" hreflang="en" href="https://liberwerk.github.io/contact.html" />
+  <link rel="alternate" hreflang="ja" href="https://liberwerk.github.io/contact.html?lang=ja" />
+  <link rel="alternate" hreflang="ko" href="https://liberwerk.github.io/contact.html?lang=ko" />
+  <link rel="alternate" hreflang="x-default" href="https://liberwerk.github.io/contact.html" />
+
+  <!-- Open Graph -->
+  <meta property="og:type"        content="website" />
+  <meta property="og:url"         content="https://liberwerk.github.io/contact.html" />
+  <meta property="og:title"       content="Get in Touch — LiberWerk" />
+  <meta property="og:description" content="Enquire about advisory services — CTO-as-a-Service, VP of Engineering consulting, and technical advisory by Mark Hahn." />
+  <meta property="og:image"       content="https://liberwerk.github.io/assets/og-image.jpg" />
+  <meta property="og:locale"      content="en_US" />
+  <meta property="og:locale:alternate" content="ja_JP" />
+  <meta property="og:locale:alternate" content="ko_KR" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card"        content="summary_large_image" />
+  <meta name="twitter:title"       content="Get in Touch — LiberWerk" />
+  <meta name="twitter:description" content="Enquire about advisory services — CTO-as-a-Service, VP of Engineering consulting, and technical advisory by Mark Hahn." />
+  <meta name="twitter:image"       content="https://liberwerk.github.io/assets/og-image.jpg" />
+
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Context
Issue #43 — contact.html missing hreflang alternates, Open Graph, and Twitter Card meta tags.

## What
- Add hreflang alternate links for en/ja/ko/x-default
- Add Open Graph meta tags
- Add Twitter Card meta tags

## Why
Social shares of the contact URL show no preview. Search engines cannot identify the multilingual contact page.

## Completion Criteria
- [ ] hreflang links added
- [ ] OG meta added
- [ ] Twitter Card meta added

close #43