### PR TITLE
feat: add sitemap link tag to HTML pages and create robots.txt

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -10,6 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="main.css" />
   <link rel="stylesheet" href="contact.css" />
+  <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
 </head>
 <body class="contact-page">
 

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="main.css" />
+  <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
 </head>
 <body>
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://liberwerk.github.io/sitemap.xml


### PR DESCRIPTION
## Context
Issue #44 — sitemap.xml exists but is not linked from HTML pages and there is no robots.txt.

## What
- Add `<link rel="sitemap">` to index.html and contact.html
- Create robots.txt pointing to sitemap

## Why
Search engine crawlers cannot discover the sitemap, reducing indexing efficiency.

## Completion Criteria
- [ ] sitemap link tag in both HTML files
- [ ] robots.txt created

close #44