### PR TITLE
chore: add package.json and npm ecosystem to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       prefix: "ci"
     labels:
       - "dependencies"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "tangoenskai-github-io",
+  "version": "1.0.0",
+  "private": true,
+  "description": "LiberWerk site — npm dev dependencies tracked for Dependabot",
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "serve": "^14.2.4",
+    "wait-on": "^8.0.1"
+  }
+}


### PR DESCRIPTION
## Context
Issue #49 — Dependabot only tracks github-actions ecosystem. npm packages installed inline in CI are untracked.

## What
- Add package.json with pinned npm dependencies used in CI
- Add npm ecosystem to dependabot.yml

## Why
Untracked npm versions may silently receive breaking changes in CI runs.

## Completion Criteria
- [ ] package.json added
- [ ] dependabot.yml updated with npm entry

close #49