### PR TITLE
ci: harden GitHub Actions workflows for security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-html:
     name: HTML Lint
@@ -22,7 +25,7 @@ jobs:
         run: npm install -g htmlhint
 
       - name: Run HTMLHint
-        run: htmlhint "**/*.html" --config .htmlhintrc
+        run: htmlhint "*.html" --config .htmlhintrc
 
   check-links:
     name: Broken Link Check

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   i18n-coverage:
     name: Translation Key Coverage

--- a/.github/workflows/sync-to-liberwerkio.yml
+++ b/.github/workflows/sync-to-liberwerkio.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     name: Mirror to LiberWerk.github.io
@@ -17,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up SSH deploy key
-        uses: webfactory/ssh-agent@v0.10.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.LIBERWERKIO_DEPLOY_KEY }}
 


### PR DESCRIPTION
## Context
Security hardening from code review — GitHub Actions workflow improvements (issues #38, #45, #46).

## What
- Add `permissions: contents: read` to ci.yml, i18n-check.yml, sync-to-liberwerkio.yml
- Restrict HTMLHint glob from `**/*.html` to `*.html`
- Pin webfactory/ssh-agent to full commit SHA

## Why
Least-privilege principle for GITHUB_TOKEN; SHA pinning prevents supply-chain attacks on the action that handles SSH deploy keys; narrower glob avoids false positives from asset files.

## Completion Criteria
- [ ] All workflows have `permissions: contents: read`
- [ ] HTMLHint scans only root-level HTML files
- [ ] ssh-agent pinned to SHA

close #38
close #45
close #46