### PR TITLE
fix: show About sidebar above bio text on mobile

### DIFF
--- a/main.css
+++ b/main.css
@@ -922,6 +922,13 @@ body {
   .nav-links { display: none; }
   .nav-cta { display: none; }
   .footer-inner { flex-direction: column; gap: 0.5rem; text-align: center; }
+
+  /* About section — single-column stack on mobile */
+  .about-grid { grid-template-columns: 1fr; gap: 2rem; }
+  .about-photo { order: 1; }
+  .about-sidebar { display: block; order: 2; }
+  .about-text { order: 3; }
+
   .hero-inner { grid-template-columns: 1fr; gap: 2.5rem; padding: 60px 0; }
   .hero-stats { flex-direction: row; flex-wrap: wrap; border-left: none; padding-left: 0; border-top: 1px solid var(--border); padding-top: 2rem; gap: 1.5rem; }
   .hero-stat-number { font-size: 2rem; }


### PR DESCRIPTION
## Context
Issue #61 — On mobile the About section sidebar (education, skills, languages) was stacking below the bio text, hiding key trust signals.

## What
Add CSS in `main.css` `@media (max-width: 768px)` block:
- `.about-grid`: single-column layout
- `.about-sidebar`: `display: block` (override 1100px hide) + `order: 2`
- `.about-text`: `order: 3`

## Why
Business visitors on mobile should see credentials before reading the full bio.

## Completion Criteria
- [x] Sidebar appears above bio on mobile (375px)
- [x] Desktop layout unchanged

close #61